### PR TITLE
doc: new specs

### DIFF
--- a/doc/01-usage.md
+++ b/doc/01-usage.md
@@ -1,6 +1,6 @@
 #Usage
 
-###Simple use
+##Simple use
 
 ```
 <?php
@@ -27,7 +27,7 @@ $appleclient->push($message);
 
 ```
 
-###Complete use
+##Complete use
 
 ```
 <?php
@@ -67,3 +67,48 @@ $appleclient = new AppleClient(__DIR__.'/data/myssl.pem', 'my_passphrase', 'http
 $appleclient->setLogger($log);
 $appleclient->push($message);
 ```
+
+##The differents messages types
+
+###Message
+```
+$message = new Message();
+$message
+        ->setNotificationTitle('This is the message title')
+        //set apple specifics attributes (ignored for gcmClients)
+	->setData(array('myKey' => 'myValue'))
+        //set android specifics attributes (ignored for appleClients)
+	->setCollapseKey('myCollapseKey')
+```
+
+Has seen in the example, the Message is the more global model that can take all parameters for both Apple and Gcm message.
+This even include specifics parameters (like data for apple or collapseKey for gcm).
+So, if a message with gcm-only parameters is given to an AppleClient, the gcm parameters will be ignored.
+It is usefull when you need to manage both client type with specifics message parameters of each one.
+
+#AppleMessage and GcmMessage
+```
+$appleMessage = new AppleMessage();
+$appleMessage
+        ->setNotificationTitle('This is the message title')
+	->setData(array('myKey' => 'myValue'))
+
+$gcmMessage = new GcmMessage();
+$gcmMessage
+        ->setNotificationTitle('This is the message title')
+	->setCollapseKey('myCollapseKey')
+```
+This Messages type have the same functionnalities than the global Message, but they are specifics to there respectives client.
+They will only take parameters that the client can understand.
+They are usefull if you only need one type of Client or if you want manage Apple and Gcm client separatly.
+
+
+#SimpleMessage
+```
+$message = new SimpleMessage();
+$message
+        ->setNotificationTitle('This is the message title')
+```
+The SimpleMessage can only manage parameters that can be used by both Apple and Gcm client.
+No specifics parameters can be provided.
+It can be usefull when you want to send the same message to each type of client, without being flooded by all the specifics parameters.

--- a/doc/01-usage.md
+++ b/doc/01-usage.md
@@ -1,36 +1,33 @@
 #Usage
 
-###Google Cloud Messaging
+###Simple use
 
 ```
 <?php
 
 require "../vendor/autoload.php";
 
+use LinkValue\MobileNotif\Model\Message;
 use LinkValue\MobileNotif\Client\GcmClient;
-use LinkValue\MobileNotif\Model\GcmMessage;
-use Monolog\Logger;
-use Monolog\Handler\StreamHandler;
+use LinkValue\MobileNotif\Client\AppleClient;
 
-$log = new Logger('notif');
-$log->pushHandler(new StreamHandler(__DIR__.'/notif.log', Logger::INFO));
+//create the message to push
+$message = new Message();
+$message
+	->setNotificationTitle('This is the message title')
+	->setNotificationBody('This is the message body');
 
-$client = new GcmClient($log);
-$client->setUp(array(
-    'endpoint' => 'https://android.googleapis.com/gcm/send',
-    'api_access_key' => 'API ACCEESS KEY',
-));
+//push notification to android device
+$gcmClient = new GcmClient('API ACCEESS KEY');
+$gcmClient->push($message);
 
-$message = new GcmMessage();
-$message->addToken('THE TOKEN HERE');
-$message->setNotificationTitle('This is the message title');
-$message->setNotificationBody('This is the message body');
-
-$client->push($message);
+//push notification to apple device
+$appleclient = new AppleClient(__DIR__.'/data/myssl.pem', 'my_passphrase');
+$appleclient->push($message);
 
 ```
 
-###Apple Push Notification Server
+###Complete use
 
 ```
 <?php
@@ -42,20 +39,31 @@ use LinkValue\MobileNotif\Model\AppleMessage;
 use Monolog\Logger;
 use Monolog\Handler\StreamHandler;
 
-$log = new Logger('notif');
-$log->pushHandler(new StreamHandler(__DIR__.'/notif.log', Logger::INFO));
 
-$client = new AppleClient($log);
-$client->setUp(array(
-    'endpoint' => 'tls://gateway.sandbox.push.apple.com:2195',
-    'ssl_pem_path' => __DIR__.'/data/myssl.pem',
-    'ssl_passphrase' => 'my_passphrase',
-));
 
-$message = new AppleMessage();
-$message->addToken('THE TOKEN HERE');
-$message->setAlertTitle('This is the message title');
-$message->setAlertBody('This is the message body');
+//create the message to push
+$message = new Message();
+$message
+	->setNotificationTitle('This is the message title')
+	->setNotificationBody('This is the message body')
+	->addToken('TOKEN 1')
+	->addToken('TOKEN 2')
+	//set apple specifics attributes (ignored for gcmClients)
+	->setData(array('myKey' => 'myValue'))
+	//set android specifics attributes (ignored for appleClients)
+	->setCollapseKey('myCollapseKey')
 
-$client->push($message);
+//create logger
+$logger = new Logger('notif');
+$logger->pushHandler(new StreamHandler(__DIR__.'/notif.log', Logger::INFO));
+
+//push notification to android device with logger
+$gcmClient = new GcmClient('API ACCEESS KEY', 'https://mypersonnalEndPoint');
+$gcmClient->setLogger($logger);
+$gcmClient->push($message);
+
+//push notification to apple device with logger
+$appleclient = new AppleClient(__DIR__.'/data/myssl.pem', 'my_passphrase', 'https://mypersonnalEndPoint');
+$appleclient->setLogger($log);
+$appleclient->push($message);
 ```


### PR DESCRIPTION
Porposition de specs sous forme de doc d'utilisation

En quelque mots, ce changement de specs a pour but que cette lib soit utilisable plus facilement par un humain. On garde les fonctions publiques qui permettent l'utilisation en bundle mais on propose aux devs qui veulent utiliser la lib tel quel de le faire plus simplement.

Pour voir les différences qu'apporterai ces specs je vous conseil d'uitliser la vue par branche, pluto car par le change file:
master: https://github.com/LinkValue/MobileNotif/blob/master/doc/01-usage.md
pull request: https://github.com/LinkValue/MobileNotif/blob/change-specs/doc/01-usage.md

Le plus gros changement qui impactera directement le projet symfony concerne le model Message unique. L'idée est de faire en sorte que les devs puisse faire abstraction du client utilisé lors de la création du message, ce qui n'est pas possible pour l'instant car il faut créer un GcmMessage ou un AppleMessage. 
